### PR TITLE
refactor: Move form.save into try block

### DIFF
--- a/allauth/account/views.py
+++ b/allauth/account/views.py
@@ -226,10 +226,11 @@ class SignupView(RedirectAuthenticatedUserMixin, CloseableSignupMixin,
         return ret
 
     def form_valid(self, form):
-        # By assigning the User to a property on the view, we allow subclasses
-        # of SignupView to access the newly created User instance
-        self.user = form.save(self.request)
         try:
+            # By assigning the User to a property on the view, we allow subclasses
+            # of SignupView to access the newly created User instance
+            self.user = form.save(self.request)
+            
             return complete_signup(
                 self.request, self.user,
                 app_settings.EMAIL_VERIFICATION,


### PR DESCRIPTION
This change allows `adapter`s that override `form.save` to perform additional custom logic and interrupt the signup flow by using the `ImmediateHTTPResponse` convention.

## General

 - [x] Make sure you use [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages).
       Examples: `"fix(google): Fixed foobar bug"`, `"feat(accounts): Added foobar feature"`.
 - [x] All Python code must be 100% pep8 and isort clean.
 - [ ] JavaScript code should adhere to [StandardJS](https://standardjs.com).
 - [ ] If your changes are significant, please update `ChangeLog.rst`.
 - [ ] Feel free to add yourself to `AUTHORS`.
 
 ## Provider Specifics
 
 In case you add a new provider:
 
- [ ] Make sure unit tests are available.
- [ ] Add an entry of your provider in `test_settings.py::INSTALLED_APPS` and `docs/installation.rst::INSTALLED_APPS`.
- [ ] Add documentation to `docs/providers.rst`.
- [ ] Add an entry to the list of supported providers over at `docs/overview.rst`.
